### PR TITLE
Résolution erreur de date test EventCard

### DIFF
--- a/src/components/EventCard/index.test.js
+++ b/src/components/EventCard/index.test.js
@@ -3,11 +3,15 @@ import EventCard from "./index";
 
 describe("When a event card is created", () => {
   it("an image is display with alt value", () => {
-    render(<EventCard imageSrc="http://src-image" imageAlt="image-alt-text" date={new Date("2022-04-01")} 
-    title="test event"
-    
-    label="test label"
-    />);
+    render(
+      <EventCard
+        imageSrc="http://src-image"
+        imageAlt="image-alt-text"
+        date={new Date("2022-04-01")}
+        title="test event"
+        label="test label"
+      />
+    );
     const imageElement = screen.getByTestId("card-image-testid");
     expect(imageElement).toBeInTheDocument();
     expect(imageElement.alt).toEqual("image-alt-text");
@@ -19,7 +23,7 @@ describe("When a event card is created", () => {
         imageAlt="image-alt-text"
         title="test event"
         label="test label"
-        date={new Date("2022-04-01")}
+        date={new Date("2022/04/01")}
       />
     );
     const titleElement = screen.getByText(/test event/);
@@ -37,7 +41,7 @@ describe("When a event card is created", () => {
           imageAlt="image-alt-text"
           title="test event"
           label="test label"
-          date={new Date("2022-04-01")}
+          date={new Date("2022/04/01")}
           small
         />
       );


### PR DESCRIPTION
Erreur de symbole pour la date ( - au lieu de / ) qui créer de multiple éléments.